### PR TITLE
Update Wolkers puzzles

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -62,7 +62,7 @@ Online research environment for working with ego documents written by soldiers i
 The International Image Interoperability Framework (IIIF) portal for Leiden University aims to help
 users access the UBL digital collections via the various IIIF APIs and services based on the IIIF.
 
-## [Jan Wolkers puzzles](https://iiif.universiteitleiden.nl/view/puzzles.html)
+## [Jan Wolkers puzzles](https://lab.library.universiteitleiden.nl/iiif-demo/puzzles.html)
 
 The CDS used existing IIIF software to make a few of Jan Wolkers's works available as puzzles.
 Read more about this on the short [project page](projects/wolkers-puzzles.md).

--- a/docs/projects/wolkers-puzzles.md
+++ b/docs/projects/wolkers-puzzles.md
@@ -4,5 +4,5 @@ title: Jan Wolkers puzzles
 
 As part of the Waanzinnige Wolkers Week, the CDS and Special Collections department of
 Leiden University Libraries selected six images of Jan Wolkers's works and himself and
-created an [online puzzle](https://iiif.universiteitleiden.nl/view/puzzles.html).
+created an [online puzzle](https://lab.library.universiteitleiden.nl/iiif-demo/puzzles.html).
 


### PR DESCRIPTION
This fixes #2 by updating the links to the Wolkers puzzles on the homepage and project page.