### PR TITLE
Update CI for creating development and production HTML

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,20 +1,34 @@
-name: Pages
+name: Build and publish webpages
 on:
   push:
     branches:
       - develop
+      - main
+
+permissions:
+  contents: write
+
 jobs:
-  build:
+  build-and-publish:
     runs-on: ubuntu-latest
     steps:
       - continue-on-error: false
         name: checkout
-        uses: actions/checkout@v3
-      # - name: Set up Python
-      #   uses: actions/setup-python@v4
-      #   with:
-      #     python-version: '3.x'
-      - name: Deploy docs
-        uses: mhausenblas/mkdocs-deploy-gh-pages@1.25
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.13'
+          cache: 'pip'
+      - name: Install dependencies
+        run: pip install -r requirements.txt
+      - name: Build docs
+        run: mkdocs build
+      - name: Deploy built docs
+        uses: peaceiris/actions-gh-pages@v4
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: ./site
+          publish_branch: ${{ github.ref }}-html

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -14,7 +14,8 @@ extra_css:
 plugins:
   - search
   - htmlproofer
-  - git-revision-date
+  - git-revision-date-localized:
+      type: iso_datetime
 
 markdown_extensions:
   - admonition

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
-mkdocs-ubleiden-theme
-mkdocs-htmlproofer-plugin >= 0.0.2
-mkdocs-git-revision-date-plugin >= 0.2
+mkdocs == 1.6.1
+mkdocs-ubleiden-theme == 1.1.0
+mkdocs-htmlproofer-plugin == 1.3.0
+mkdocs-git-revision-date-localized-plugin == 1.3.0


### PR DESCRIPTION
Now that we have a development and a production environment, it would be great to have the site be built for both environments.

The idea of this PR is that the contents of the `develop` branch are rendered and pushed to `develop-html` and the `main` branch's contents are rendered and pushed to `main-html` (for the production environment). These branches should be protected. We need to have a workflow in place to synchronise good commits from `develop` to `main`.
We currently do not use GitHub environments.

We replaced the `git-revision-date` plugin with `git-revision-date-localized` and pinned all dependencies in `requirements.txt` so that caching can work.