### PR TITLE
Relax version constraint for theme

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 mkdocs == 1.6.1
-mkdocs-ubleiden-theme == 1.1.0
+mkdocs-ubleiden-theme >= 1.0.0
 mkdocs-htmlproofer-plugin == 1.3.0
 mkdocs-git-revision-date-localized-plugin == 1.3.0


### PR DESCRIPTION
I'm updating the theme, but for now let's just let the CI build the site with any version 1.0.0 or up.