### PR TITLE
Use ref_name to derive valid GH branch name

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,4 +31,4 @@ jobs:
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: ./site
-          publish_branch: ${{ github.ref }}-html
+          publish_branch: ${{ github.ref_name }}-html


### PR DESCRIPTION
GitHub does not accept pushing branches whose name starts with `refs/`. The CI should have used `github.ref_name` to get the short branch name.