### PR TITLE
Fix broken links for now

### DIFF
--- a/docs/projects/nk-posters.md
+++ b/docs/projects/nk-posters.md
@@ -5,6 +5,6 @@ title: North-Korean poster collection
 The CDS helped convert the detailed descriptions of propaganda posters from North Korea
 to metadata that could be ingested into the [Digital Collections repository][dc].
 This is an excellent example of the support we offer for making your research data
-more FAIR and available in the long term. See [VREs](/vre/) for more information.
+more FAIR and available in the long term. See [VREs](/vre/index.md) for more information.
 
 [dc]: https://digitalcollections.universiteitleiden.nl

--- a/docs/vre/index.md
+++ b/docs/vre/index.md
@@ -4,10 +4,8 @@ title: Virtual Research Environments
 
 # What is a Virtual Research Environment (VRE)?
 
-See the [Libraries' website on VREs][vre] to learn more about VREs and what
-Leiden University Libraries can do for you.
-
-[vre]: https://www.library.universiteitleiden.nl/researchers/use-of-digital-data/vre
+A Virtual Research Environment is an online system that supports research tasks,
+specifically collecting, analysing and sharing data in a way that fits the project.
 
 # Types of VREs
 
@@ -17,7 +15,7 @@ many fields.
 
 ## SharePoint
 
-[Library-managed VREs][vre] are based on Microsoft SharePoint. They allow collaborating on
+The Libraries supported VREs that were based on Microsoft SharePoint. They allow collaborating on
 (office) documents, sharing files, and storing information in (a collection of interlinked)
 lists, among other features. The lists functionality is like a database and can be accessed
 from Microsoft Access and Microsoft Excel.
@@ -25,7 +23,8 @@ from Microsoft Access and Microsoft Excel.
 ## GitLab
 
 [GitLab](https://about.gitlab.com/) is an online version control system based on [git][].
-The University hosts a GitLab service that you can use after logging in with your ULCN credentials:
+The University hosts a GitLab service that you can use from the university network or EduVPN
+after logging in with your ULCN credentials:
 <https://gitlab.services.universiteitleiden.nl/>.
 
 Git is most often used for versioning and sharing software source code, but it works with

--- a/docs/working-with-data/index.md
+++ b/docs/working-with-data/index.md
@@ -13,7 +13,7 @@ There are various other cycles that are used to guide data management,
 discussed by Alex Ball in [Review of Data Management Lifecycle Models (2012)][ball].
 
 [ukdsc]: https://www.ukdataservice.ac.uk/manage-data/lifecycle.aspx
-[ball]: http://opus.bath.ac.uk/28587/
+[ball]: https://researchportal.bath.ac.uk/en/publications/review-of-data-management-lifecycle-models
 
 # Creating data
 

--- a/docs/working-with-data/processing-data/htr.md
+++ b/docs/working-with-data/processing-data/htr.md
@@ -35,5 +35,5 @@ part of the [PSL Scripta] project.
 Permission from the project partners is needed to use the platform,
 or you need to set up your own service.
 
-[eScriptorium]: https://escriptorium.fr/
+[eScriptorium]: https://msia.escriptorium.fr/
 [PSL Scripta]: https://www.psl.eu/en/scripta

--- a/docs/working-with-data/publishing-data/nanopublications.md
+++ b/docs/working-with-data/publishing-data/nanopublications.md
@@ -14,5 +14,5 @@ Although nanopubs can be distributed as files, there is an elaborate system
 of applications to help create nanopubs and server applications to publish
 them.
 
-[Nanopublications]: http://nanopub.org
+[Nanopublications]: https://nanopub.net
 [RDF]: https://www.w3.org/TR/rdf11-concepts/

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -13,7 +13,9 @@ extra_css:
 
 plugins:
   - search
-  - htmlproofer
+  - htmlproofer:
+      ignore_urls:
+        - https://gitlab.services.universiteitleiden.nl/
   - git-revision-date-localized:
       type: iso_datetime
 


### PR DESCRIPTION
Links that `htmlproofer` flagged have been updated or deleted, except for the one to Leiden's GitLab service for research, because we know it is valid, just not accessible. It was therefor added to the ignored URLs list.